### PR TITLE
Attempt at making Apple login work on the web

### DIFF
--- a/ios/Plugin/FirebaseAuthentication.swift
+++ b/ios/Plugin/FirebaseAuthentication.swift
@@ -84,20 +84,28 @@ import FirebaseAuth
         Auth.auth().useAppLanguage()
     }
 
-    func handleSuccessfulSignIn(credential: AuthCredential) {
+    func handleSuccessfulSignIn(credential: AuthCredential, rawNonce: String? = nil) {
+        let skipNativeLogin = true
+        var result = JSObject()
+        
+        result["credential"] = FirebaseAuthenticationHelper.createCredentialResultFromFirebaseCredential(credential)
+        result["rawNonce"] = rawNonce
+        
+        if (skipNativeLogin) {
+            savedCall?.resolve(result)
+            return
+        }
+        
         Auth.auth().signIn(with: credential) { (_, error) in
             if let error = error {
                 self.handleFailedSignIn(error: error)
                 return
             }
-            guard let savedCall = self.savedCall else {
-                return
-            }
+
             let user = self.getCurrentUser()
-            let userResult = FirebaseAuthenticationHelper.createUserResultFromFirebaseUser(user)
-            var result = JSObject()
-            result["user"] = userResult
-            savedCall.resolve(result)
+            result["user"] = FirebaseAuthenticationHelper.createUserResultFromFirebaseUser(user)
+
+            self.savedCall?.resolve(result)
         }
     }
 

--- a/ios/Plugin/FirebaseAuthentication.swift
+++ b/ios/Plugin/FirebaseAuthentication.swift
@@ -84,12 +84,13 @@ import FirebaseAuth
         Auth.auth().useAppLanguage()
     }
 
-    func handleSuccessfulSignIn(credential: AuthCredential, rawNonce: String? = nil) {
+    func handleSuccessfulSignIn(credential: AuthCredential, idToken: String? = nil, rawNonce: String? = nil, accessToken: String? = nil) {
         let skipNativeLogin = true
         var result = JSObject()
         
-        result["credential"] = FirebaseAuthenticationHelper.createCredentialResultFromFirebaseCredential(credential)
+        result["idToken"] = idToken
         result["rawNonce"] = rawNonce
+        result["accessToken"] = accessToken
         
         if (skipNativeLogin) {
             savedCall?.resolve(result)

--- a/ios/Plugin/FirebaseAuthenticationHelper.swift
+++ b/ios/Plugin/FirebaseAuthenticationHelper.swift
@@ -20,18 +20,4 @@ public class FirebaseAuthenticationHelper {
         result["uid"] = user?.uid
         return result
     }
-    
-    public static func createCredentialResultFromFirebaseCredential(_ credential: AuthCredential) -> JSObject? {
-        if let credential = credential as? OAuthCredential {            
-            var result = JSObject()
-            result["providerId"] = credential.provider
-            result["idToken"] = credential.idToken
-            result["accessToken"] = credential.accessToken
-            return result
-        } else {
-            var result = JSObject()
-            result["providerId"] = credential.provider
-            return result
-        }
-    }
 }

--- a/ios/Plugin/FirebaseAuthenticationHelper.swift
+++ b/ios/Plugin/FirebaseAuthenticationHelper.swift
@@ -20,4 +20,18 @@ public class FirebaseAuthenticationHelper {
         result["uid"] = user?.uid
         return result
     }
+    
+    public static func createCredentialResultFromFirebaseCredential(_ credential: AuthCredential) -> JSObject? {
+        if let credential = credential as? OAuthCredential {            
+            var result = JSObject()
+            result["providerId"] = credential.provider
+            result["idToken"] = credential.idToken
+            result["accessToken"] = credential.accessToken
+            return result
+        } else {
+            var result = JSObject()
+            result["providerId"] = credential.provider
+            return result
+        }
+    }
 }

--- a/ios/Plugin/Handlers/AppleAuthProviderHandler.swift
+++ b/ios/Plugin/Handlers/AppleAuthProviderHandler.swift
@@ -106,7 +106,11 @@ extension AppleAuthProviderHandler: ASAuthorizationControllerDelegate, ASAuthori
         }
         let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
     
-        self.pluginImplementation.handleSuccessfulSignIn(credential: credential, rawNonce: nonce)
+        self.pluginImplementation.handleSuccessfulSignIn(
+            credential: credential,
+            idToken: idTokenString,
+            rawNonce: nonce
+        )
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {

--- a/ios/Plugin/Handlers/AppleAuthProviderHandler.swift
+++ b/ios/Plugin/Handlers/AppleAuthProviderHandler.swift
@@ -92,6 +92,7 @@ extension AppleAuthProviderHandler: ASAuthorizationControllerDelegate, ASAuthori
         guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
             return
         }
+        
         guard let nonce = currentNonce else {
             fatalError("Invalid state: A login callback was received, but no login request was sent.")
         }
@@ -104,7 +105,8 @@ extension AppleAuthProviderHandler: ASAuthorizationControllerDelegate, ASAuthori
             return
         }
         let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
-        self.pluginImplementation.handleSuccessfulSignIn(credential: credential)
+    
+        self.pluginImplementation.handleSuccessfulSignIn(credential: credential, rawNonce: nonce)
     }
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {

--- a/ios/Plugin/Handlers/GoogleAuthProviderHandler.swift
+++ b/ios/Plugin/Handlers/GoogleAuthProviderHandler.swift
@@ -28,7 +28,11 @@ class GoogleAuthProviderHandler: NSObject {
                 guard let idToken = authentication.idToken else { return }
                 let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: authentication.accessToken)
                 
-                self.pluginImplementation.handleSuccessfulSignIn(credential: credential)
+                self.pluginImplementation.handleSuccessfulSignIn(
+                    credential: credential,
+                    idToken: idToken,
+                    accessToken: authentication.accessToken
+                )
             }
         }
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -98,8 +98,9 @@ export interface SignInResult {
    * The currently signed-in user, or null if there isn't any.
    */
   user: User | null;
-  credential: AuthCredential | OAuthCredential | null;
+  idToken: string | null;
   rawNonce: string | null;
+  accessToken: string | null;
 }
 
 export interface User {
@@ -112,14 +113,4 @@ export interface User {
   providerId: string;
   tenantId: string | null;
   uid: string;
-}
-
-export interface AuthCredential {
-  provider: string | null;
-}
-
-export interface OAuthCredential {
-  accessToken: string | null;
-  idToken: string | null;
-  providerId: string | null;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -98,6 +98,8 @@ export interface SignInResult {
    * The currently signed-in user, or null if there isn't any.
    */
   user: User | null;
+  credential: AuthCredential | OAuthCredential | null;
+  rawNonce: string | null;
 }
 
 export interface User {
@@ -110,4 +112,14 @@ export interface User {
   providerId: string;
   tenantId: string | null;
   uid: string;
+}
+
+export interface AuthCredential {
+  provider: string | null;
+}
+
+export interface OAuthCredential {
+  accessToken: string | null;
+  idToken: string | null;
+  providerId: string | null;
 }


### PR DESCRIPTION
This PR is just a proof of concept which makes auth on web-layer functional.

In `FirebaseAuthentication.swift` we're hard-wiring `skipNativeLogin = true`, which completely skips logging in in the native app, and just forwards the needed data to the web layer. **Do we have to skip on native side?** Yeah. You can't use the same tokens to login twice. See more here: https://github.com/robingenz/capacitor-firebase-authentication/issues/41#issuecomment-884731442

We're collecting and forwarding `idToken`, `rawNonce` and `accessToken`, which is all that the web layer needs to sign in.

For Google, `idToken` and `accessToken` is used:

```typescript
const {idToken, accessToken} = await FirebaseAuthentication.signInWithGoogle()
const credential = firebase.auth.GoogleAuthProvider.credential(idToken, accessToken)

await firebase.auth().signInWithCredential(credential)
```

For Apple, `idToken` and `rawNonce` is used:

```typescript
const {idToken, rawNonce} = await FirebaseAuthentication.signInWithApple()

if (!idToken || !rawNonce) {
  return
}

const provider = new firebase.auth.OAuthProvider('apple.com')
const credential = provider.credential({idToken, rawNonce})

firebase.auth().signInWithCredential(credential)
```

---

**Why can't we just forward the entire `credential` object?** For Google, it's going to be `AuthCredential`, and it's impossible to read `idToken` or `accessToken` from that object. For Apple, it's going to be `OAuthCredential`, and it's impossible to read `rawNonce` from that. (Well unless we used some private APIs.)

So it's just send these to web layer, and we allow web layer to take over and log in there.