### PR TITLE
fix: Apple sign-in (rename nonce to rawNonce)

### DIFF
--- a/docs/firebase-js-sdk.md
+++ b/docs/firebase-js-sdk.md
@@ -26,7 +26,7 @@ const signInWithApple = async () => {
   const provider = new firebase.auth.OAuthProvider('apple.com');
   const credential = provider.credential({
     idToken: result.credential?.idToken,
-    nonce: result.credential?.nonce,
+    rawNonce: result.credential?.nonce,
   });
   await firebase.auth().signInWithCredential(credential);
 };


### PR DESCRIPTION
Closes https://github.com/robingenz/capacitor-firebase-authentication/issues/68#issuecomment-907351789