### PR TITLE
fix(ios): `signInWithPhoneNumber` is not implemented

### DIFF
--- a/ios/Plugin/FirebaseAuthenticationPlugin.m
+++ b/ios/Plugin/FirebaseAuthenticationPlugin.m
@@ -14,6 +14,7 @@ CAP_PLUGIN(FirebaseAuthenticationPlugin, "FirebaseAuthentication",
            CAP_PLUGIN_METHOD(signInWithMicrosoft, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(signInWithTwitter, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(signInWithYahoo, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(signInWithPhoneNumber, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(signOut, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(useAppLanguage, CAPPluginReturnPromise);
 )


### PR DESCRIPTION
Close #72 