### PR TITLE
docs: rename "result" to "signInResult"

### DIFF
--- a/docs/firebase-js-sdk.md
+++ b/docs/firebase-js-sdk.md
@@ -25,8 +25,8 @@ const signInWithApple = async () => {
   // 2. Sign in on the web layer using the id token and nonce
   const provider = new firebase.auth.OAuthProvider('apple.com');
   const credential = provider.credential({
-    idToken: result.credential?.idToken,
-    rawNonce: result.credential?.nonce,
+    idToken: signInResult.credential?.idToken,
+    rawNonce: signInResult.credential?.nonce,
   });
   await firebase.auth().signInWithCredential(credential);
 };


### PR DESCRIPTION
Fixes small typo

`const signInResult = await FirebaseAuthentication.signInWithApple();` at line 24