### PR TITLE
feat: add `signInWithCustomToken`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ const useAppLanguage = async () => {
 * [`signInWithTwitter(...)`](#signinwithtwitter)
 * [`signInWithYahoo(...)`](#signinwithyahoo)
 * [`signInWithPhoneNumber(...)`](#signinwithphonenumber)
+* [`signInWithCustomToken(...)`](#signinwithcustomtoken)
 * [`signOut()`](#signout)
 * [`useAppLanguage()`](#useapplanguage)
 * [`addListener('authStateChange', ...)`](#addlistenerauthstatechange-)
@@ -409,6 +410,26 @@ Only available for Android and iOS.
 --------------------
 
 
+### signInWithCustomToken(...)
+
+```typescript
+signInWithCustomToken(options: SignInWithCustomTokenOptions) => Promise<SignInResult>
+```
+
+Starts the Custom Token sign-in flow.
+
+This method cannot be used in combination with `skipNativeAuth` on Android and iOS.
+In this case you have to use the `signInWithCustomToken` interface of the Firebase JS SDK directly.
+
+| Param         | Type                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------- |
+| **`options`** | <code><a href="#signinwithcustomtokenoptions">SignInWithCustomTokenOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#signinresult">SignInResult</a>&gt;</code>
+
+--------------------
+
+
 ### signOut()
 
 ```typescript
@@ -554,6 +575,13 @@ Remove all listeners for this plugin.
 | **`phoneNumber`**      | <code>string</code> | The phone number to be verified.                                                                                                                    |
 | **`verificationId`**   | <code>string</code> | The verification ID which will be returned when `signInWithPhoneNumber` is called for the first time. The `verificationCode` must also be provided. |
 | **`verificationCode`** | <code>string</code> | The verification code from the SMS message. The `verificationId` must also be provided.                                                             |
+
+
+#### SignInWithCustomTokenOptions
+
+| Prop        | Type                | Description                       |
+| ----------- | ------------------- | --------------------------------- |
+| **`token`** | <code>string</code> | The custom token to sign in with. |
 
 
 #### PluginListenerHandle

--- a/android/src/main/java/dev/robingenz/capacitorjs/plugins/firebase/auth/FirebaseAuthenticationPlugin.java
+++ b/android/src/main/java/dev/robingenz/capacitorjs/plugins/firebase/auth/FirebaseAuthenticationPlugin.java
@@ -120,6 +120,11 @@ public class FirebaseAuthenticationPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void signInWithCustomToken(PluginCall call) {
+        implementation.signInWithCustomToken(call);
+    }
+
+    @PluginMethod
     public void signOut(PluginCall call) {
         implementation.signOut(call);
     }

--- a/ios/Plugin/FirebaseAuthenticationPlugin.m
+++ b/ios/Plugin/FirebaseAuthenticationPlugin.m
@@ -16,6 +16,7 @@ CAP_PLUGIN(FirebaseAuthenticationPlugin, "FirebaseAuthentication",
            CAP_PLUGIN_METHOD(signInWithTwitter, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(signInWithYahoo, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(signInWithPhoneNumber, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(signInWithCustomToken, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(signOut, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(useAppLanguage, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/FirebaseAuthenticationPlugin.swift
+++ b/ios/Plugin/FirebaseAuthenticationPlugin.swift
@@ -94,6 +94,10 @@ public class FirebaseAuthenticationPlugin: CAPPlugin {
         implementation?.signInWithYahoo(call)
     }
 
+    @objc func signInWithCustomToken(_ call: CAPPluginCall) {
+        implementation?.signInWithCustomToken(call)
+    }
+
     @objc func signOut(_ call: CAPPluginCall) {
         implementation?.signOut(call)
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -89,6 +89,15 @@ export interface FirebaseAuthenticationPlugin {
     options: SignInWithPhoneNumberOptions,
   ): Promise<SignInWithPhoneNumberResult>;
   /**
+   * Starts the Custom Token sign-in flow.
+   *
+   * This method cannot be used in combination with `skipNativeAuth` on Android and iOS.
+   * In this case you have to use the `signInWithCustomToken` interface of the Firebase JS SDK directly.
+   */
+  signInWithCustomToken(
+    options: SignInWithCustomTokenOptions,
+  ): Promise<SignInResult>;
+  /**
    * Starts the sign-out flow.
    */
   signOut(): Promise<void>;
@@ -172,6 +181,13 @@ export interface SignInWithPhoneNumberOptions {
    * The `verificationId` must also be provided.
    */
   verificationCode?: string;
+}
+
+export interface SignInWithCustomTokenOptions {
+  /**
+   * The custom token to sign in with.
+   */
+  token: string;
 }
 
 export interface SignInResult {

--- a/src/web.ts
+++ b/src/web.ts
@@ -10,6 +10,7 @@ import {
   OAuthCredential,
   OAuthProvider,
   signInWithPopup,
+  signInWithCustomToken,
 } from 'firebase/auth';
 
 import type {
@@ -21,6 +22,7 @@ import type {
   SetLanguageCodeOptions,
   SignInResult,
   SignInWithPhoneNumberOptions,
+  SignInWithCustomTokenOptions,
   User,
 } from './definitions';
 
@@ -120,6 +122,14 @@ export class FirebaseAuthenticationWeb
     _options: SignInWithPhoneNumberOptions,
   ): Promise<SignInResult> {
     throw new Error('Not implemented on web.');
+  }
+
+  public async signInWithCustomToken(
+    options: SignInWithCustomTokenOptions,
+  ): Promise<SignInResult> {
+    const auth = getAuth();
+    const result = await signInWithCustomToken(auth, options.token);
+    return this.createSignInResult(result.user, null);
   }
 
   public async signOut(): Promise<void> {


### PR DESCRIPTION
Hi,

this PR adds the `signInWithCustomToken` feature.
https://firebase.google.com/docs/auth/android/custom-auth

The authentication only works on the native layer for android and ios because no credential object is returned from the firebase sdk.
The custom token must be known in the web layer anyway and therefore the web layer can be authenticated directly using the js-sdk.

Thanks for this awesome plugin!
