### PR TITLE
Fix Facebook  Sing-In docs - activity element

### DIFF
--- a/docs/setup-facebook.md
+++ b/docs/setup-facebook.md
@@ -13,7 +13,7 @@
 
    `[APP_ID]` must be replaced with your Facebook app ID.
 
-1. Add the following elements to `android/app/src/main/AndroidManifest.xml` after the `application` element:
+1. Add the following elements to `android/app/src/main/AndroidManifest.xml` inside the `application` element:
 
    ```xml
    <meta-data


### PR DESCRIPTION
According to [FB documentation](https://developers.facebook.com/docs/facebook-login/android) the `meta-data` and `activity` should be **inside** the application element:

See section 5 in the link:
```
Add the following meta-data element, an activity for Facebook, and an activity and intent filter for Chrome Custom Tabs inside your application element:
```