### PR TITLE
refactor: update casing

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -174,6 +174,7 @@ export class FirebaseAuthenticationWeb
       isAnonymous: user.isAnonymous,
       phoneNumber: user.phoneNumber,
       photoURL: user.photoURL,
+      photoUrl: user.photoURL,
       providerId: user.providerId,
       tenantId: user.tenantId,
       uid: user.uid,

--- a/src/web.ts
+++ b/src/web.ts
@@ -173,7 +173,7 @@ export class FirebaseAuthenticationWeb
       emailVerified: user.emailVerified,
       isAnonymous: user.isAnonymous,
       phoneNumber: user.phoneNumber,
-      photoUrl: user.photoURL,
+      photoURL: user.photoURL,
       providerId: user.providerId,
       tenantId: user.tenantId,
       uid: user.uid,


### PR DESCRIPTION
TL;DR - Update field name from `photoUrl` to `photoURL`.

Following the pattern of how the fields are assigned, all of the fields are using the same case rules except for photo URL field which was `photoUrl` instead of `photoURL`.